### PR TITLE
Release-6.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # node-oracledb-prebuilt-for-lambda
 
  - This module is forked from the currently un-maintained [node-oracledb-for-lambda](https://github.com/nalbion/node-oracledb-for-lambda).
- - Core oracledb libraries are derived from [node-oracledb](https://github.com/oracle/node-oracledb) v6.0.1
- - 6.0.1: Prebuilt for use with AWS Lambda nodejs16.x Runtime
- - Also tested to work with AWS Lambda nodejs14.x and nodejs18.x Runtime
+ - Core oracledb libraries are derived from [node-oracledb](https://github.com/oracle/node-oracledb) v6.0.3
+ - 6.0.3: Prebuilt for use with AWS Lambda nodejs18.x Runtime
+ - Also tested to work with AWS Lambda nodejs14.x, nodejs16.x, and nodejs18.x Runtime
  
 The scripts to reproduce the build process can be found at [node-oracledb-lambda-test](https://github.com/romanbalayan/node-oracledb-lambda-test). 
 
 # Usage
 
 ```bash
-npm install --save oracledb-prebuilt-for-lambda@6.0.1
+npm install --save oracledb-prebuilt-for-lambda@6.0.3
 ```
 
 # Versioning
  - Changed release version to match that of underlying node-oracledb version. 
- - i.e. for release based on oracledb 6.0.1, release will be oracledb-prebuilt-for-lambda@6.0.1
+ - i.e. for release based on oracledb 6.0.3, release will be oracledb-prebuilt-for-lambda@6.0.3
  
  
  # Releases
  | node-oracledb       | oracledb-prebuilt-for-lambda    |
  | ------------------- | ---------- |
+ | 6.0.3               | 6.0.3      |
  | 6.0.1               | 6.0.1      |
  | 5.5.0               | 5.5.0      |
  | 5.4.0               | 5.4.0      |
@@ -34,6 +35,7 @@ npm install --save oracledb-prebuilt-for-lambda@6.0.1
 
  
  # Changelog
+ - v6.0.3: [node-oracledb v6.0.3 changelog](https://node-oracledb.readthedocs.io/en/latest/release_notes.html#node-oracledb-v6-0-3-12-jul-2023)
  - v6.0.1: [node-oracledb v6.0.1 changelog](https://node-oracledb.readthedocs.io/en/latest/release_notes.html#node-oracledb-v6-0-1-07-jun-2023)
  - v5.5.0: [node-oracledb v5.5.0 changelog](https://github.com/oracle/node-oracledb/blob/main/CHANGELOG.md#node-oracledb-v550-7-sep-2022)
  - v5.4.0: [node-oracledb v5.4.0 changelog](https://github.com/oracle/node-oracledb/blob/main/CHANGELOG.md#node-oracledb-v540-9-jun-2022)

--- a/index.js
+++ b/index.js
@@ -1,1 +1,27 @@
+// Copyright (c) 2015, 2023, Oracle and/or its affiliates.
+
+//-----------------------------------------------------------------------------
+//
+// This software is dual-licensed to you under the Universal Permissive License
+// (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+// 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+// either license.
+//
+// If you elect to accept the software under the Apache License, Version 2.0,
+// the following applies:
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//-----------------------------------------------------------------------------
+
 module.exports = require('./lib/oracledb.js');

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -146,6 +146,7 @@ class Connection extends EventEmitter {
       cls = this._buildDbObjectClass(objType);
       cls._connection = this;
       cls._objType = objType;
+      objType._connection = this._impl;
       this._dbObjectClasses.set(objType, cls);
     }
     return (cls);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -161,7 +161,8 @@ const ERR_INVALID_SID = 519;
 const ERR_TNS_NAMES_FILE_MISSING = 520;
 const ERR_CONNECTION_EOF = 521;
 
-// define mapping for ODPI-C errors that need to be wrapped with NJS errors
+// define mapping for ODPI-C, OCI & ORA errors that need to be wrapped
+// with NJS errors
 const adjustErrorXref = new Map();
 adjustErrorXref.set("DPI-1010", ERR_CONNECTION_CLOSED);
 adjustErrorXref.set("DPI-1024", [ERR_INVALID_COLL_INDEX_GET, 'at index ([0-9]+) does']);
@@ -327,7 +328,7 @@ messages.set(ERR_MISSING_CREDENTIALS,                   // NJS-101
 messages.set(ERR_UNEXPECTED_END_OF_DATA,                // NJS-102
   'unexpected end of data: want %d bytes but only %d bytes are available');
 messages.set(ERR_UNEXPECTED_MESSAGE_TYPE,               // NJS-103
-  'unexpected message type %d received');
+  'unexpected message type %d received at position %d of packet %d');
 messages.set(ERR_POOL_HAS_BUSY_CONNECTIONS,             // NJS-104
   'connection pool cannot be closed because connections are busy');
 messages.set(ERR_NAN_VALUE,                             // NJS-105
@@ -343,9 +344,9 @@ messages.set(ERR_INVALID_TYPE_NUM,                      // NJS-109
 messages.set(ERR_INVALID_ORACLE_TYPE_NUM,               // NJS-110
   'invalid Oracle type number %d [csfrm: %d]');
 messages.set(ERR_UNEXPECTED_NEGATIVE_INTEGER,           // NJS-111
-  'internal error: read a negative integer when expecting a positive integer');
+  'internal error: read a negative integer when expecting a positive integer at position %d of packet %d');
 messages.set(ERR_INTEGER_TOO_LARGE,                     // NJS-112
-  'internal error: read integer of length %d when expecting integer of no more than length %d');
+  'internal error: read integer of length %d when expecting integer of no more than length %d at position %d of packet %d');
 messages.set(ERR_UNEXPECTED_DATA,                       // NJS-113
   'unexpected data received: %s');
 messages.set(ERR_OSON_FIELD_NAME_LIMITATION,            // NJS-114

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -47,6 +47,7 @@ class Pool extends EventEmitter {
     this._timeOfReset = this._createdDate = Date.now();
     this._sessionCallback = undefined;
     this._connRequestQueue = [];
+    this._connectionClass = settings.connectionClass;
   }
 
   //---------------------------------------------------------------------------
@@ -376,7 +377,9 @@ class Pool extends EventEmitter {
       errors.assertParamValue(nodbUtil.isObject(a1), 1);
       options = this._verifyGetConnectionOptions(a1);
     }
-    settings.addToOptions(options, "connectionClass");
+
+    // get connection class value from pool
+    options.connectionClass = this._connectionClass;
 
     // if pool is draining/closed, throw an appropriate error
     this._checkPoolOpen(true);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -69,7 +69,7 @@ class Settings {
   // database are returned as though they used the JavaScript time zone
   // setting. TIMESTAMP WITH TIME ZONE and TIMESTAMP WITH LOCAL TIME ZONE data
   // are returned in native JavaScript format (since they contain time zone
-  // information).
+  // information). This is used only in Thick mode (from node-oracledb 6.0.0).
   //---------------------------------------------------------------------------
   _getDateComponents(useLocal, date) {
     if (useLocal) {

--- a/lib/thin/dbObject.js
+++ b/lib/thin/dbObject.js
@@ -36,6 +36,19 @@ const { GrowableBuffer } = require('./protocol/buffer.js');
 class DbObjectPickleBuffer extends GrowableBuffer {
 
   //---------------------------------------------------------------------------
+  // _readBytesWithLength()
+  //
+  // Helper function that processes the number of bytes (if needed) and then
+  // acquires the specified number of bytes from the buffer.
+  //---------------------------------------------------------------------------
+  _readBytesWithLength(numBytes) {
+    if (numBytes === constants.TNS_LONG_LENGTH_INDICATOR) {
+      numBytes = this.readUInt32BE();
+    }
+    return this.readBytes(numBytes);
+  }
+
+  //---------------------------------------------------------------------------
   // getIsAtomicNull()
   //
   // Reads the next byte and checks to see if the value is atomically null. If
@@ -349,12 +362,12 @@ class ThinDbObjectImpl extends DbObjectImpl {
         return buf.readBinaryInteger();
       case types.DB_TYPE_VARCHAR:
       case types.DB_TYPE_CHAR:
-        return buf.readStr(constants.TNS_CS_IMPLICIT);
+        return buf.readStr(constants.CSFRM_IMPLICIT);
       case types.DB_TYPE_NVARCHAR:
       case types.DB_TYPE_NCHAR:
-        return buf.readStr(constants.TNS_CS_NCHAR);
+        return buf.readStr(constants.CSFRM_NCHAR);
       case types.DB_TYPE_RAW:
-        return buf.readBytesWithLength();
+        return Buffer.from(buf.readBytesWithLength());
       case types.DB_TYPE_BINARY_DOUBLE:
         return buf.readBinaryDouble();
       case types.DB_TYPE_BINARY_FLOAT:
@@ -365,7 +378,6 @@ class ThinDbObjectImpl extends DbObjectImpl {
       case types.DB_TYPE_TIMESTAMP_LTZ:
       case types.DB_TYPE_TIMESTAMP_TZ:
         return buf.readOracleDate(false);
-      case types.DB_TYPE_BLOB:
       case types.DB_TYPE_BOOLEAN:
         return buf.readBool();
       case types.DB_TYPE_OBJECT:
@@ -374,7 +386,7 @@ class ThinDbObjectImpl extends DbObjectImpl {
           return null;
         obj = new ThinDbObjectImpl(typeClass);
         if (obj._objType.isCollection || this._objType.isCollection) {
-          obj.packedData = buf.readBytesWithLength();
+          obj.packedData = Buffer.from(buf.readBytesWithLength());
         } else {
           obj._unpackDataFromBuf(buf);
         }

--- a/lib/thin/lob.js
+++ b/lib/thin/lob.js
@@ -121,10 +121,10 @@ class ThinLobImpl extends LobImpl {
   }
 
   getCsfrm() {
-    if (this.dbType._csfrm !== constants.TNS_CS_NCHAR) {
+    if (this.dbType._csfrm !== constants.CSFRM_NCHAR) {
       if (this._locator[constants.TNS_LOB_LOC_OFFSET_FLAG_3] &
           constants.TNS_LOB_LOC_FLAGS_VAR_LENGTH_CHARSET) {
-        return constants.TNS_CS_NCHAR;
+        return constants.CSFRM_NCHAR;
       }
     }
     return this.dbType._csfrm;

--- a/lib/thin/pool.js
+++ b/lib/thin/pool.js
@@ -144,13 +144,13 @@ class ThinPoolImpl extends PoolImpl {
   }
 
   //---------------------------------------------------------------------------
-  // get connection from pool
+  // credentials are obfuscated and stored in an object(userConfig) during
+  // pool creation. _getConnAttrs() method is used to deobfuscate encrypted
+  // credentials for creating new connections
   //---------------------------------------------------------------------------
-  async _connect(connAttrs) {
+  async _getConnAttrs() {
     let accessToken;
-    const conn = new ThinConnectionImpl();
-    conn._pool = this;
-    let clonedAttrs = Object.assign({}, connAttrs);
+    const clonedAttrs = Object.assign({}, this._userConfig);
     if (clonedAttrs.password === null) {
       clonedAttrs.password = protocolUtil.getDeobfuscatedValue(this._password,
         this._obfuscatedPassword);
@@ -204,9 +204,7 @@ class ThinPoolImpl extends PoolImpl {
         protocolUtil.getDeobfuscatedValue(this._privateKey,
           this._obfuscatedPrivateKey);
     }
-    await conn.connect(clonedAttrs);
-    clonedAttrs = null;
-    return conn;
+    return clonedAttrs;
   }
 
   //---------------------------------------------------------------------------
@@ -214,9 +212,6 @@ class ThinPoolImpl extends PoolImpl {
   // create new connection and return it
   //---------------------------------------------------------------------------
   async getConnection() {
-    if (settings.connectionClass !== '') {
-      this._userConfig.connectionClass = settings.connectionClass;
-    }
     return await this.acquire();
   }
 
@@ -318,8 +313,11 @@ class ThinPoolImpl extends PoolImpl {
   // Grows the pool to include the specified number of connections.
   //---------------------------------------------------------------------------
   async _growPool(numConns) {
+    const clonedAttrs = await this._getConnAttrs();
     while (numConns > 0) {
-      let conn = await this._connect(this._userConfig);
+      const conn = new ThinConnectionImpl();
+      conn._pool = this;
+      await conn.connect(clonedAttrs);
       conn._newSession = true;
       conn._dropSess = false;
       conn._lastTimeUsed = Date.now();

--- a/lib/thin/protocol/buffer.js
+++ b/lib/thin/protocol/buffer.js
@@ -92,13 +92,13 @@ class BaseBuffer {
       return 0;
     } else if (size & 0x80) {
       if (!signed) {
-        errors.throwErr(errors.ERR_UNEXPECTED_NEGATIVE_INTEGER);
+        errors.throwErr(errors.ERR_UNEXPECTED_NEGATIVE_INTEGER, this.pos, this.packetNum);
       }
       isNegative = true;
       size = size & 0x7f;
     }
     if (size > maxSize) {
-      errors.throwErr(errors.ERR_INTEGER_TOO_LARGE, size, maxSize);
+      errors.throwErr(errors.ERR_INTEGER_TOO_LARGE, size, maxSize, this.pos, this.packetNum);
     }
     if (skip) {
       this.skipBytes(size);
@@ -375,18 +375,18 @@ class BaseBuffer {
     const obj = {};
     let numBytes = this.readUB4();
     if (numBytes > 0)
-      obj.toid = this.readBytesWithLength();
+      obj.toid = Buffer.from(this.readBytesWithLength());
     numBytes = this.readUB4();
     if (numBytes > 0)
-      obj.oid = this.readBytesWithLength();
+      obj.oid = Buffer.from(this.readBytesWithLength());
     numBytes = this.readUB4();
     if (numBytes > 0)
-      obj.snapshot = this.readBytesWithLength();
+      obj.snapshot = Buffer.from(this.readBytesWithLength());
     this.skipUB2();                     // version
     numBytes = this.readUB4();
     this.skipUB2();                     // flags
     if (numBytes > 0)
-      obj.packedData = this.readBytesWithLength();
+      obj.packedData = Buffer.from(this.readBytesWithLength());
     return obj;
   }
 
@@ -465,7 +465,7 @@ class BaseBuffer {
     if (!buf) {
       return null;
     }
-    if (csfrm === constants.TNS_CS_IMPLICIT)
+    if (csfrm === constants.CSFRM_IMPLICIT)
       return buf.toString();
 
     // need a copy of the buffer since swap16() changes the buffer in place and
@@ -748,7 +748,7 @@ class BaseBuffer {
     const ptr = this.reserveBytes(length);
     if (type === types.DB_TYPE_DATE || type == types.DB_TYPE_TIMESTAMP) {
       const year = date.getFullYear();
-      ptr[0] = Math.floor(year / 100) + 100;
+      ptr[0] = Math.trunc(year / 100) + 100;
       ptr[1] = year % 100 + 100;
       ptr[2] = date.getMonth() + 1;
       ptr[3] = date.getDate();
@@ -757,7 +757,7 @@ class BaseBuffer {
       ptr[6] = date.getSeconds() + 1;
     } else {
       const year = date.getUTCFullYear();
-      ptr[0] = Math.floor(year / 100) + 100;
+      ptr[0] = Math.trunc(year / 100) + 100;
       ptr[1] = year % 100 + 100;
       ptr[2] = date.getUTCMonth() + 1;
       ptr[3] = date.getUTCDate();

--- a/lib/thin/protocol/constants.js
+++ b/lib/thin/protocol/constants.js
@@ -40,7 +40,12 @@ module.exports = {
     constants.VERSION_MAJOR << 24 |
     constants.VERSION_MINOR << 20 |
     constants.VERSION_PATCH << 12,
+  CSFRM_IMPLICIT: constants.CSFRM_IMPLICIT,
+  CSFRM_NCHAR: constants.CSFRM_NCHAR,
   DRIVER_NAME: constants.DEFAULT_DRIVER_NAME + ' thn',
+  PURITY_DEFAULT: constants.PURITY_DEFAULT,
+  PURITY_NEW: constants.PURITY_NEW,
+  PURITY_SELF: constants.PURITY_SELF,
   SYSASM: constants.SYSASM,
   SYSBKP: constants.SYSBKP,
   SYSDBA: constants.SYSDBA,
@@ -87,10 +92,6 @@ module.exports = {
   // marker types
   TNS_MARKER_TYPE_BREAK: 1,
   TNS_MARKER_TYPE_RESET: 2,
-
-  // charset forms
-  TNS_CS_IMPLICIT: 1,
-  TNS_CS_NCHAR: 2,
 
   // data types
   TNS_DATA_TYPE_DEFAULT: 0,

--- a/lib/thin/protocol/encryptDecrypt.js
+++ b/lib/thin/protocol/encryptDecrypt.js
@@ -138,18 +138,30 @@ class EncryptDecrypt {
     if (newPassword) {
       newPasswordBytes = Buffer.from(newPassword, 'utf8');
     }
-    let sessionKeyParta = this._decrypt(passwordHash, encodedServerKey);
-    let sessionKeyPartb = Buffer.alloc(32);
-    crypto.randomFillSync(sessionKeyPartb, 0, 32);
-    let encodedClientKey = this._encrypt(passwordHash, sessionKeyPartb);
-    authObj.sessionKey = encodedClientKey.slice().toString('hex').toUpperCase().slice(0, 64);
+    const sessionKeyParta = this._decrypt(passwordHash, encodedServerKey);
+    const sessionKeyPartb = Buffer.alloc(sessionKeyParta.length);
+    crypto.randomFillSync(sessionKeyPartb);
+    const encodedClientKey = this._encrypt(passwordHash, sessionKeyPartb);
 
-    iterations = Number(sessionData['AUTH_PBKDF2_SDER_COUNT']);
-    let mixingSalt = Buffer.from(sessionData['AUTH_PBKDF2_CSK_SALT'], 'hex');
-    let partABKey = Buffer.concat([sessionKeyPartb.slice(0, keyLen), sessionKeyParta.slice(0, keyLen)]);
-    let partABKeyStr = partABKey.toString('hex').toUpperCase();
-    let partABKeyBuffer = Buffer.from(partABKeyStr, 'utf8');
-    authObj.comboKey = crypto.pbkdf2Sync(partABKeyBuffer, mixingSalt, iterations, keyLen, 'sha512');
+    if (sessionKeyParta.length === 48) {
+      authObj.sessionKey = encodedClientKey.slice().toString('hex').toUpperCase().slice(0, 96);
+      const buf = Buffer.alloc(24);
+      for (let i = 16; i <= 40; i++) {
+        buf[i - 16] = sessionKeyParta[i] ^ sessionKeyPartb[i];
+      }
+      const part1 = crypto.createHash("md5").update(buf.subarray(0, 16)).digest();
+      const part2 = crypto.createHash("md5").update(buf.subarray(16)).digest();
+      authObj.comboKey = Buffer.concat([part1, part2]).slice(0, keyLen);
+    } else {
+      authObj.sessionKey = encodedClientKey.slice().toString('hex').toUpperCase().slice(0, 64);
+      const mixingSalt = Buffer.from(sessionData['AUTH_PBKDF2_CSK_SALT'], 'hex');
+      iterations = Number(sessionData['AUTH_PBKDF2_SDER_COUNT']);
+      const partABKey = Buffer.concat([sessionKeyPartb.slice(0, keyLen), sessionKeyParta.slice(0, keyLen)]);
+      const partABKeyStr = partABKey.toString('hex').toUpperCase();
+      const partABKeyBuffer = Buffer.from(partABKeyStr, 'utf8');
+      authObj.comboKey = crypto.pbkdf2Sync(partABKeyBuffer, mixingSalt,
+        iterations, keyLen, 'sha512');
+    }
 
     let salt = Buffer.alloc(16);
     if (!verifier11G) {

--- a/lib/thin/protocol/messages/auth.js
+++ b/lib/thin/protocol/messages/auth.js
@@ -29,12 +29,11 @@
 const { Buffer } = require('buffer');
 const constants = require("../constants.js");
 const errors = require("../../../errors.js");
-const os = require("os");
 const process = require("process");
 const ED = require("../encryptDecrypt.js");
 const Message = require("./base.js");
 const util = require("../../util.js");
-
+const cInfo = util.CLIENT_INFO;
 const crypto = require('crypto');
 
 /**
@@ -184,11 +183,10 @@ class AuthMessage extends Message {
         buf.writeBytesWithLength(Buffer.from(this.username));
       }
       buf.writeKeyValue("AUTH_TERMINAL", "unknown");
-      buf.writeKeyValue("AUTH_PROGRAM_NM", process.argv0);
-      buf.writeKeyValue("AUTH_MACHINE", os.hostname());
-      buf.writeKeyValue("AUTH_PID", process.pid.toString());
-      buf.writeKeyValue("AUTH_SID", os.userInfo().username);
-
+      buf.writeKeyValue("AUTH_PROGRAM_NM", cInfo.program);
+      buf.writeKeyValue("AUTH_MACHINE", cInfo.hostName);
+      buf.writeKeyValue("AUTH_PID", cInfo.pid);
+      buf.writeKeyValue("AUTH_SID", cInfo.userName);
     } else {
       let numPairs = 0;
 
@@ -302,11 +300,11 @@ class AuthMessage extends Message {
     let numParams = buf.readUB2();
     for (let i = 0; i < numParams;i++) {
       buf.skipUB4();
-      let key = buf.readStr(constants.TNS_CS_IMPLICIT);
+      let key = buf.readStr(constants.CSFRM_IMPLICIT);
       let value = "";
       let numBytes = buf.readUB4();
       if (numBytes > 0) {
-        value = buf.readStr(constants.TNS_CS_IMPLICIT);
+        value = buf.readStr(constants.CSFRM_IMPLICIT);
       }
       let flag = buf.readUB4();
       if (key === "AUTH_VFR_DATA") {

--- a/lib/thin/protocol/messages/base.js
+++ b/lib/thin/protocol/messages/base.js
@@ -149,7 +149,7 @@ class Message {
       for (let i = 0; i < numEntries; i++) {
         buf.skipUB2();                          // skip chunk length
 
-        this.errorInfo.batchErrors[i].message = buf.readStr(constants.TNS_CS_IMPLICIT);
+        this.errorInfo.batchErrors[i].message = buf.readStr(constants.CSFRM_IMPLICIT);
         buf.skipBytes(2);                       // ignore end marker
       }
     }
@@ -158,7 +158,7 @@ class Message {
     this.errorInfo.rowCount = buf.readUB8();    // row number (extended)
     if (this.errorInfo.num !== 0) {
       this.errorOccurred = true;
-      this.errorInfo.message = buf.readStr(constants.TNS_CS_IMPLICIT);
+      this.errorInfo.message = buf.readStr(constants.CSFRM_IMPLICIT);
       /*
        * Remove ending newline from ORA error message
        */
@@ -175,7 +175,7 @@ class Message {
     let numBytes = buf.readUB2();               // length of error message
     buf.skipUB2();                              // flags
     if (this.errorInfo.num != 0 && numBytes > 0) {
-      this.errorInfo.message = buf.readStr(constants.TNS_CS_IMPLICIT);
+      this.errorInfo.message = buf.readStr(constants.CSFRM_IMPLICIT);
     }
     this.errorInfo.isWarning = true;
   }
@@ -215,7 +215,7 @@ class Message {
     } else if (messageType === constants.TNS_MSG_TYPE_SERVER_SIDE_PIGGYBACK) {
       this.processServerSidePiggyBack(buf);
     } else {
-      errors.throwErr(errors.ERR_UNEXPECTED_MESSAGE_TYPE, messageType);
+      errors.throwErr(errors.ERR_UNEXPECTED_MESSAGE_TYPE, messageType, buf.pos, buf.packetNum);
     }
   }
 
@@ -230,8 +230,8 @@ class Message {
      || (opcode === constants.TNS_SERVER_PIGGYBACK_TRACE_EVENT)) {
       // pass
     } else if (opcode === constants.TNS_SERVER_PIGGYBACK_OS_PID_MTS) {
-      const nb = buf.readUB2();
-      buf.skipBytes(nb + 1);
+      buf.skipUB2();
+      buf.skipBytesChunked();
     } else if (opcode === constants.TNS_SERVER_PIGGYBACK_SYNC) {
       buf.skipUB2();                            // skip number of DTYs
       buf.skipUB1();                            // skip length of DTYs
@@ -240,11 +240,11 @@ class Message {
       for (let i = 0; i < num_elements; i++) {
         let temp16 = buf.readUB2();
         if (temp16 > 0) {                       // skip key
-          buf.skipBytes(temp16 + 1);
+          buf.skipBytesChunked();
         }
         temp16 = buf.readUB2();
         if (temp16 > 0) {                       // skip value
-          buf.skipBytes(temp16 + 1);
+          buf.skipBytesChunked();
         }
         buf.skipUB2();                          // skip flags
         buf.skipUB4();                          // skip overall flags
@@ -271,11 +271,11 @@ class Message {
         for (let i = 0; i < num_elements; ++i) {
           let temp16 = buf.readUB2();
           if (temp16 > 0) {                     // skip key
-            buf.skipBytes(temp16 + 1);
+            buf.skipBytesChunked();
           }
           temp16 = buf.readUB2();
           if (temp16 > 0) {                     // skip value
-            buf.skipBytes(temp16 + 1);
+            buf.skipBytesChunked();
           }
           buf.skipUB2();                        // skip flags
         }

--- a/lib/thin/protocol/messages/execute.js
+++ b/lib/thin/protocol/messages/execute.js
@@ -77,20 +77,20 @@ class ExecuteMessage extends MessageWithData {
       dmlOptions = constants.TNS_EXEC_OPTION_IMPLICIT_RESULTSET;
       options |= constants.TNS_EXEC_OPTION_EXECUTE;
     }
-    if (stmt.cursorId == 0 || stmt.isDdl) {
+    if (stmt.cursorId === 0 || stmt.isDdl) {
       options |= constants.TNS_EXEC_OPTION_PARSE;
     }
     if (stmt.isQuery) {
       if (this.parseOnly) {
         options |= constants.TNS_EXEC_OPTION_DESCRIBE;
       } else {
-        if (this.options.prefetchRows > 0) {
-          options |= constants.TNS_EXEC_OPTION_FETCH;
-        }
         if (stmt.cursorId === 0 || stmt.requiresDefine) {
           numIters = this.options.prefetchRows;
         } else {
           numIters = this.options.fetchArraySize;
+        }
+        if (numIters > 0 && !stmt.noPrefetch) {
+          options |= constants.TNS_EXEC_OPTION_FETCH;
         }
       }
     }
@@ -276,7 +276,7 @@ class ExecuteMessage extends MessageWithData {
     if (this.currentRow === 0) {
       let stmt = this.statement;
       if (stmt.cursorId !== 0 && !stmt.requiresFullExecute && !this.parseOnly && !stmt.requiresDefine && !stmt.isDdl && !this.batchErrors) {
-        if (stmt.isQuery && !stmt.requiresDefine && this.options.prefetchRows > 0) {
+        if (stmt.isQuery && !stmt.requiresDefine && !stmt.noPrefetch && this.options.prefetchRows > 0) {
           this.functionCode = constants.TNS_FUNC_REEXECUTE_AND_FETCH;
         } else {
           this.functionCode = constants.TNS_FUNC_REEXECUTE;

--- a/lib/thin/protocol/messages/lobOp.js
+++ b/lib/thin/protocol/messages/lobOp.js
@@ -116,7 +116,7 @@ class LobOpMessage extends Message {
       buf.writeBytes(this.destLobImpl._locator);
     }
     if (this.operation === constants.TNS_LOB_OP_CREATE_TEMP) {
-      if (this.sourceLobImpl.dbType._csfrm === constants.TNS_CS_NCHAR) {
+      if (this.sourceLobImpl.dbType._csfrm === constants.CSFRM_NCHAR) {
         buf.caps.checkNCharsetId();
         buf.writeUB4(constants.TNS_CHARSET_UTF16);
       } else {
@@ -128,7 +128,7 @@ class LobOpMessage extends Message {
       buf.writeUInt8(constants.TNS_MSG_TYPE_LOB_DATA);
       if (this.sourceLobImpl.dbType._oraTypeNum === constants.TNS_DATA_TYPE_BLOB) {
         data = this.data;
-      } else if (this.sourceLobImpl.getCsfrm() === constants.TNS_CS_NCHAR) {
+      } else if (this.sourceLobImpl.getCsfrm() === constants.CSFRM_NCHAR) {
         data = this.data;
         // TODO: avoid conversion back to string, if possible
         // this is since bind data is converted to buffer automatically, but if
@@ -154,7 +154,7 @@ class LobOpMessage extends Message {
       if (data !== null) {
         if (oraTypeNum === constants.TNS_DATA_TYPE_BLOB) {
           data = Buffer.from(data);
-        } else if (this.sourceLobImpl.getCsfrm() === constants.TNS_CS_NCHAR) {
+        } else if (this.sourceLobImpl.getCsfrm() === constants.CSFRM_NCHAR) {
           data = Buffer.from(data).swap16().toString('utf16le');
         } else {
           data = data.toString();

--- a/lib/thin/protocol/messages/withData.js
+++ b/lib/thin/protocol/messages/withData.js
@@ -139,7 +139,7 @@ class MessageWithData extends Message {
 
     let numBytes = buf.readUB4();
     if (numBytes > 0) {
-      buf.skipBytes(numBytes + 1);              // current date
+      buf.skipBytesChunked();                   // current date
     }
     buf.skipUB4();                              // dcbflag
     buf.skipUB4();                              // dcbmdbz
@@ -147,7 +147,7 @@ class MessageWithData extends Message {
     buf.skipUB4();                              // dcbmxpr
     numBytes = buf.readUB4();
     if (numBytes > 0) {
-      buf.skipBytes(numBytes + 1);
+      buf.skipBytesChunked();
     }
 
     this.resultSetsToSetup.push(resultSet);
@@ -173,7 +173,7 @@ class MessageWithData extends Message {
     let oid;
     let numBytes = buf.readUB4();               // OID
     if (numBytes > 0) {
-      oid = buf.readBytesWithLength();
+      oid = Buffer.from(buf.readBytesWithLength());
     }
     buf.skipUB2();                              // version
     buf.skipUB2();                              // character set id
@@ -190,17 +190,17 @@ class MessageWithData extends Message {
     let name;
     numBytes = buf.readUB4();
     if (numBytes > 0) {
-      name = buf.readStr(constants.TNS_CS_IMPLICIT);
+      name = buf.readStr(constants.CSFRM_IMPLICIT);
     }
     let schema;
     numBytes = buf.readUB4();
     if (numBytes > 0) {
-      schema = buf.readStr(constants.TNS_CS_IMPLICIT);
+      schema = buf.readStr(constants.CSFRM_IMPLICIT);
     }
     numBytes = buf.readUB4();
     let typeName;
     if (numBytes > 0) {
-      typeName = buf.readStr(constants.TNS_CS_IMPLICIT);
+      typeName = buf.readStr(constants.CSFRM_IMPLICIT);
     }
     buf.skipUB2();                              // column position
     buf.skipUB4();                              // uds flag
@@ -316,10 +316,11 @@ class MessageWithData extends Message {
   processIOVector(buf) {
     let numBytes;
     buf.skipUB1();                              // flag
-    const numBinds = buf.readUB2();             // num requests
-    this.rowIndex = buf.readUB4();              // iter num
+    const temp16 = buf.readUB2();              // num requests
+    const temp32 = buf.readUB4();              // iter num
+    const numBinds = temp32 * 256 + temp16;
     buf.skipUB4();                              // num iters this time
-    buf.readUB2();                              // uac buffer length
+    buf.skipUB2();                              // uac buffer length
     numBytes = buf.readUB2();                   // bit vector for fast fetch
     if (numBytes > 0) {
       buf.skipBytes(numBytes);
@@ -355,7 +356,7 @@ class MessageWithData extends Message {
       oraTypeNum === constants.TNS_DATA_TYPE_CHAR ||
       oraTypeNum === constants.TNS_DATA_TYPE_LONG
     ) {
-      if (csfrm === constants.TNS_CS_NCHAR) {
+      if (csfrm === constants.CSFRM_NCHAR) {
         buf.caps.checkNCharsetId();
       }
       colValue = buf.readStr(csfrm);
@@ -378,9 +379,9 @@ class MessageWithData extends Message {
       const useLocalTime = (oraTypeNum === constants.TNS_DATA_TYPE_DATE ||
         oraTypeNum === constants.TNS_DATA_TYPE_TIMESTAMP);
       colValue = buf.readOracleDate(useLocalTime);
-    }  else if (oraTypeNum === constants.TNS_DATA_TYPE_ROWID) {
+    } else if (oraTypeNum === constants.TNS_DATA_TYPE_ROWID) {
       if (!this.inFetch) {
-        colValue = buf.readStr(constants.TNS_CS_IMPLICIT);
+        colValue = buf.readStr(constants.CSFRM_IMPLICIT);
       } else {
         let numBytes = buf.readUInt8();
         if (isNullLength(numBytes)) {
@@ -392,7 +393,7 @@ class MessageWithData extends Message {
       }
     } else if (oraTypeNum === constants.TNS_DATA_TYPE_UROWID) {
       if (!this.inFetch) {
-        colValue = buf.readStr(constants.TNS_CS_IMPLICIT);
+        colValue = buf.readStr(constants.CSFRM_IMPLICIT);
       } else {
         colValue = buf.readURowID();
       }
@@ -478,7 +479,7 @@ class MessageWithData extends Message {
     for (let i = 0; i < numParams; i++) {
       numBytes = buf.readUB2();                 // key
       if (numBytes > 0) {
-        keyTextValue = buf.readStr(constants.TNS_CS_IMPLICIT);
+        keyTextValue = buf.readStr(constants.CSFRM_IMPLICIT);
       }
       numBytes = buf.readUB2();                 // value
       if (numBytes > 0) {
@@ -546,6 +547,7 @@ class MessageWithData extends Message {
             variable.maxSize = constants.TNS_MAX_LONG_LENGTH;
           }
           resultSet.statement.requiresDefine = true;
+          resultSet.statement.noPrefetch = true;
         }
       }
     }
@@ -563,7 +565,7 @@ class MessageWithData extends Message {
 
     if (this.statement.isQuery) {
       this.inFetch = true;
-      if (this.statement.queryVars)  {
+      if (this.statement.queryVars) {
         this.outVariables = [];
         for (let i = 0; i < this.statement.queryVars.length; i++) {
           this.outVariables.push(this.statement.queryVars[i]);
@@ -582,7 +584,7 @@ class MessageWithData extends Message {
   }
 
   getBitVector(buf, numBytes) {
-    this.bitVector = buf.readBytes(numBytes);
+    this.bitVector = Buffer.from(buf.readBytes(numBytes));
   }
 
   processBindParams(buf, params) {
@@ -607,7 +609,7 @@ class MessageWithData extends Message {
       // NCHAR, NVARCHAR reports ORA-01460: unimplemented or unreasonable
       // conversion requested if maxSize is not multiplied by the
       // bufferSizeFactor
-      if (variable.type._csfrm === constants.TNS_CS_NCHAR) {
+      if (variable.type._csfrm === constants.CSFRM_NCHAR) {
         maxSize *= variable.type._bufferSizeFactor;
       }
       if ([constants.TNS_DATA_TYPE_ROWID, constants.TNS_DATA_TYPE_UROWID].includes(oraTypeNum)) {
@@ -731,7 +733,7 @@ class MessageWithData extends Message {
       oraTypeNum === constants.TNS_DATA_TYPE_LONG ||
       oraTypeNum === constants.TNS_DATA_TYPE_RAW ||
       oraTypeNum === constants.TNS_DATA_TYPE_LONG_RAW) {
-      if (variable.type._csfrm === constants.TNS_CS_NCHAR) {
+      if (variable.type._csfrm === constants.CSFRM_NCHAR) {
         buf.caps.checkNCharsetId();
         value = Buffer.from(value, constants.TNS_ENCODING_UTF16).swap16();
       } else {

--- a/lib/thin/protocol/packet.js
+++ b/lib/thin/protocol/packet.js
@@ -220,12 +220,17 @@ class ReadPacket extends BaseBuffer {
     }
 
     // the requested bytes are split across multiple packets; if a chunked read
-    // is not in progress one is implicitly started; copy the bytes from the
-    // end of this packet
-    if (!inChunkedRead) {
-      this.chunkedBytesBuf.startChunkedRead();
+    // is in progress, a chunk is acquired that will accommodate the requested
+    // bytes; otherwise, a separate buffer will be allocated to accommodate the
+    // requested bytes
+    let buf;
+    if (inChunkedRead) {
+      buf = this.chunkedBytesBuf.getBuf(numBytes);
+    } else {
+      buf = Buffer.alloc(numBytes);
     }
-    const buf = this.chunkedBytesBuf.getBuf(numBytes);
+
+    // copy the bytes to the buffer from the remainder of this packet
     let offset = 0;
     this.buf.copy(buf, offset, this.pos, this.pos + numBytesLeft);
     offset += numBytesLeft;
@@ -241,10 +246,7 @@ class ReadPacket extends BaseBuffer {
       numBytes -= numSplitBytes;
     }
 
-    // if not in a chunked bytes read, return the buffer directly
-    if (!inChunkedRead) {
-      return this.chunkedBytesBuf.endChunkedRead();
-    }
+    return buf;
 
   }
 
@@ -252,46 +254,48 @@ class ReadPacket extends BaseBuffer {
    * Receives a packet from the adapter.
    */
   receivePacket() {
-    if (this.savedBufferPos === this.savedBuffers.length) {
+    if (this.savedPacketPos === this.savedPackets.length) {
       const packet = this.nsi.syncRecvPacket();
-      if (!packet)
+      if (!packet || this.nsi.isBreak)
         throw new utils.OutOfPacketsError();
-      this.savedBuffers.push(packet.buf);
+      this.savedPackets.push(packet);
     }
-    this.startPacket(this.savedBuffers[this.savedBufferPos++]);
+    this.startPacket(this.savedPackets[this.savedPacketPos++]);
   }
 
   restorePoint() {
-    this.savedBufferPos = 0;
-    this.startPacket(this.savedBuffers[this.savedBufferPos++]);
+    this.savedPacketPos = 0;
+    this.startPacket(this.savedPackets[this.savedPacketPos++]);
     this.pos = this.savedPos;
   }
 
   savePoint() {
-    if (this.savedBuffers) {
-      this.savedBuffers = this.savedBuffers.splice(this.savedBufferPos - 1);
+    if (this.savedPackets) {
+      this.savedPackets = this.savedPackets.splice(this.savedPacketPos - 1);
     } else {
-      this.savedBuffers = [this.buf];
+      this.savedPackets = [this.packet];
     }
-    this.savedBufferPos = 1;
+    this.savedPacketPos = 1;
     this.savedPos = this.pos;
   }
 
-  startPacket(buf) {
-    this.buf = buf;
+  startPacket(packet) {
+    this.packet = packet;
+    this.buf = packet.buf;
     this.pos = 10;                      // skip packet heaader and data flags
-    this.size = buf.length;
+    this.size = packet.buf.length;
+    this.packetNum = packet.num;
   }
 
   async waitForPackets() {
     const packet = await this.nsi.recvPacket();
-    if (!this.savedBuffers) {
-      this.savedBuffers = [packet.buf];
-      this.savedBufferPos = 0;
+    if (!this.savedPackets) {
+      this.savedPackets = [packet];
+      this.savedPacketPos = 0;
     } else {
-      this.savedBuffers.push(packet.buf);
+      this.savedPackets.push(packet);
     }
-    this.startPacket(this.savedBuffers[this.savedBufferPos++]);
+    this.startPacket(this.savedPackets[this.savedPacketPos++]);
   }
 
   /**

--- a/lib/thin/protocol/protocol.js
+++ b/lib/thin/protocol/protocol.js
@@ -71,6 +71,7 @@ class Protocol {
     while (true) {     // eslint-disable-line
       if (this.nsi.isBreak) {
         await this.resetMessage();
+        delete this.readBuf.savedBuffers;
         await this.readBuf.waitForPackets();
       }
       try {
@@ -78,8 +79,10 @@ class Protocol {
         break;
       } catch (err) {
         if (err instanceof utils.OutOfPacketsError) {
-          await this.readBuf.waitForPackets();
-          this.readBuf.restorePoint();
+          if (!this.nsi.isBreak) {
+            await this.readBuf.waitForPackets();
+            this.readBuf.restorePoint();
+          }
           continue;
         }
         throw (err);
@@ -108,7 +111,7 @@ class Protocol {
     this.writeBuf.endRequest();
   }
 
-  async _recoverFromError(message) {
+  async _recoverFromError(caughtErr, message) {
     /*
      * We have NJS error(protocol related) detected during packet write/read
      * operation.  Issue a break and reset to clear channel . We receive the
@@ -121,10 +124,12 @@ class Protocol {
       await this.readBuf.waitForPackets();
       message.decode(this.readBuf);
     } catch (err) { // Recovery failed
-    // TODO: throw different error indicating that reset failed, probably
-    // put inside resetMessage()
       this.nsi.disconnect();
-      errors.throwErr(errors.ERR_CONNECTION_CLOSED);
+      const newErr = errors.getErr(errors.ERR_CONNECTION_CLOSED);
+      caughtErr.message = newErr.message +
+        "\nError recovery failed: " + err.message +
+        "\nOriginal error: " + caughtErr.message;
+      throw caughtErr;
     }
   }
 
@@ -150,7 +155,7 @@ class Protocol {
     } catch (err) {
       if (!this.connInProgress &&
           err.code !== errors.ERR_CONNECTION_CLOSED_CODE) {
-        await this._recoverFromError(message);
+        await this._recoverFromError(err, message);
       }
       throw err;
     } finally {

--- a/lib/thin/sqlnet/connStrategy.js
+++ b/lib/thin/sqlnet/connStrategy.js
@@ -28,8 +28,7 @@
 
 const { NavAddress, NavAddressList, NavDescription, NavDescriptionList } = require("./navNodes.js");
 const { createNVPair } = require("./nvStrToNvPair.js");
-
-
+const errors = require("../../errors.js");
 
 /**
  * Class that holds all possible attributes under Description
@@ -166,6 +165,9 @@ async function createNode(str) {
     case "DESCRIPTION_LIST":
       navobj = new NavDescriptionList();
       break;
+    default:
+      errors.throwErr(errors.ERR_INVALID_CONNECT_STRING_PARAMETERS,
+        `unknown top element ${arg}`);
   }
   navobj.initFromNVPair(nvpair);
   let cs = new ConnStrategy();

--- a/lib/thin/sqlnet/ezConnectResolver.js
+++ b/lib/thin/sqlnet/ezConnectResolver.js
@@ -39,8 +39,7 @@ Test Case in oracle_private/ezconnectTest.js
 const HOSTNAMES_PATTERN = new RegExp("((?=(?<hostnames>(((\\[[A-z0-9:]+\\])|([A-z0-9][A-z0-9._-]+))[,]?)+)))\\k<hostnames>(:(?<port>\\d+)?)?", 'g');
 
 // The EZConnect pattern without the extended settings part.
-const EZ_URL_PATTERN = new RegExp("^((?<protocol>tcp|tcps):)?"
-    + "(//)?"
+const EZ_URL_PATTERN = new RegExp("^(((?<protocol>[A-z0-9]+):)?//)?"
     + "(?<hostinfo>(" + HOSTNAMES_PATTERN.source + "(?=([,]|[;]|[/]|[:]|$))([,]|[;])?)+)"
     + "(/(?<servicename>[A-z0-9][A-z0-9,-.]+)?)"
     + "?(:(?<servermode>dedicated|shared|pooled))"
@@ -145,8 +144,9 @@ class EZConnectResolver {
     if (protocol == null) {
       if (!(url.includes("//")))
         protocol = 'TCP';
+    } else if (protocol.toLowerCase() != 'tcp' && protocol.toLowerCase() != 'tcps') {
+      errors.throwErr(errors.ERR_INVALID_EZCONNECT_SYNTAX, 'Unsupported protocol in thin mode', protocol);
     }
-
     // Try to get the proxy information from URL properties
     const proxyHost = this.urlProps.get("HTTPS_PROXY");
     const proxyPort = this.urlProps.get("HTTPS_PROXY_PORT");
@@ -216,8 +216,12 @@ class EZConnectResolver {
     let ipcnt = 0;
     let builder = new Array();
     let proxyInfo = '';
-    if (proxyHost != null && proxyPort != null) {
-      proxyInfo = `(HTTPS_PROXY=${proxyHost})(HTTPS_PROXY_PORT=${proxyPort})`;
+    if (proxyHost != null) {
+      if (proxyPort != null) {
+        proxyInfo = `(HTTPS_PROXY=${proxyHost})(HTTPS_PROXY_PORT=${proxyPort})`;
+      } else {
+        proxyInfo = `(HTTPS_PROXY=${proxyHost})`;
+      }
     }
 
     if (protocol == null) protocol = 'TCP';

--- a/lib/thin/sqlnet/navNodes.js
+++ b/lib/thin/sqlnet/navNodes.js
@@ -32,6 +32,7 @@ const os = require("os");
 const net = require('net');
 const dns = require('dns');
 const dnsPromises = dns.promises;
+const cInfo = require("../util.js").CLIENT_INFO;
 
 const SchemaObjectFactoryInterface = {
   ADDR:0,
@@ -443,7 +444,6 @@ const NavSchemaObject = {
   LB: "(LOAD_BALANCE=yes)",
   NFO: "(FAILOVER=false)",
   CD: "(CONNECT_DATA=",
-  CID: `(CID=(PROGRAM=nodejs)(HOST=${os.hostname()})(USER=${os.userInfo().username}))`,
   CONID: "(CONNECTION_ID="
 };
 const options = {
@@ -770,10 +770,10 @@ class NavDescription extends Description {
       if (this.connectData == null) {
         this.connectData = "(SERVICE_NAME=)";
       }
-
+      const cid = `(CID=(PROGRAM=${cInfo.program})(HOST=${cInfo.hostName})(USER=${cInfo.userName}))`;
       cOpts[i].CNdata.push(NavSchemaObject.CD);
       cOpts[i].CNdata.push(this.connectData);
-      cOpts[i].CNdata.push(NavSchemaObject.CID);
+      cOpts[i].CNdata.push(cid);
       cOpts[i].CNdata.push(")");
 
       if (this.SID != null) {

--- a/lib/thin/sqlnet/networkSession.js
+++ b/lib/thin/sqlnet/networkSession.js
@@ -165,6 +165,9 @@ class NetworkSession {
    * Make the transport level connection
    */
   async transportConnect(address) {
+    if (address.protocol.toUpperCase() == 'TCP' && address.httpsProxy) {
+      errors.throwErr(errors.ERR_INVALID_CONNECT_STRING_PARAMETERS, 'https proxy requires protocol as', 'tcps ');
+    }
     if (address.protocol && (address.protocol.toUpperCase() == 'TCP' || address.protocol.toUpperCase() == 'TCPS')) {
       this.ntAdapter = new NTTCP(this.sAtts.nt);
     } else {
@@ -173,8 +176,8 @@ class NetworkSession {
     await this.ntAdapter.connect(address);
     this.ntAdapter.startRead();
     this.sAtts.ntCha = this.ntAdapter.cha;
-    this.sndDatapkt = new Packet.DataPacket(this.sAtts.sdu, this.sAtts.largeSDU);
-    this.rcvDatapkt = new Packet.DataPacket(this.sAtts.sdu, this.sAtts.largeSDU);
+    this.sndDatapkt = new Packet.DataPacket(this.sAtts.largeSDU);
+    this.rcvDatapkt = new Packet.DataPacket(this.sAtts.largeSDU);
   }
 
   /**
@@ -280,17 +283,16 @@ class NetworkSession {
         }
 
         connectPkt = new Packet.ConnectPacket(redirConnData, this.sAtts, constants.NSPFRDR);
+        this.sndDatapkt = new Packet.DataPacket(this.sAtts.largeSDU);
         this._sendConnect(connectPkt);
       }
     }
 
     /* Accepted  */
     this.connected = true;
-    this.rcvDatapkt = new Packet.DataPacket(this.sAtts.sdu, this.sAtts.largeSDU);
-    this.rcvDatapkt.offset = this.rcvDatapkt.dataPtr;
-    this.rcvDatapkt.len = this.rcvDatapkt.dataPtr;
-    this.sndDatapkt = new Packet.DataPacket(this.sAtts.sdu, this.sAtts.largeSDU);
-    this.sndDatapkt.createPacket();
+    this.cData = null;
+    this.sndDatapkt = new Packet.DataPacket(this.sAtts.largeSDU);
+    this.sndDatapkt.createPacket(constants.NSPDADAT); //Currently only used for disconnect
     this.sndDatapkt.offset = this.sndDatapkt.dataPtr;
     this.sndDatapkt.len = this.sndDatapkt.bufLen;
     this.markerPkt = new Packet.MarkerPacket(this.sAtts.largeSDU);
@@ -466,7 +468,7 @@ class NetworkSession {
     let bytesCopied = 0;
 
     this.sndDatapkt.dataLen = this.sndDatapkt.offset;
-    if (this.sndDatapkt.dataLen < this.sndDatapkt.bufLen) {
+    if (this.sndDatapkt.dataLen < this.sndDatapkt.bufLen || !this.sndDatapkt.bufLen) {
       bytesCopied = this.sndDatapkt.fillBuf(userBuf, offset, len);
       len -= bytesCopied;
       offset += bytesCopied;
@@ -591,7 +593,6 @@ class NetworkSession {
     let error = 0;
     if (this.controlPkt.errno) {     /* Control pkt already read */
       error = this.controlPkt.errno;
-      this.controlPkt.clear(); /* Clear error */
       return (error);
     } else if (!this.getOption(constants.HEALTHCHECK)) {
       return errors.ERR_CONNECTION_CLOSED;
@@ -602,7 +603,6 @@ class NetworkSession {
         if (packet.type == constants.NSPTCNL) {
           this.controlPkt.fromPacket(packet);
           error = this.controlPkt.errno;
-          this.controlPkt.clear(); /* Clear error */
           return (error);
         } else {
           this.ntAdapter.packets.unshift(packet); /* Push packet back */

--- a/lib/thin/sqlnet/ntTcp.js
+++ b/lib/thin/sqlnet/ntTcp.js
@@ -47,6 +47,8 @@ const TCPCHA = 1 << 1 |    /* ASYNC support */
   1 << 9 |    /* Full Duplex support */
   1 << 12;    /* SIGPIPE Support */
 
+let streamNum = 1;
+
 /**
  * Network Transport TCP/TCPS adapter
  * @param {Address} address Destination Address
@@ -63,6 +65,8 @@ class NTTCP {
     this.numPacketsSinceLastWait = 0;
     this.secure = false;
     this.largeSDU = false;
+    this.streamNum = streamNum++;
+    this.packetNum = 1;
   }
 
   /**
@@ -240,7 +244,8 @@ class NTTCP {
     }
     this.stream = null;
     this.connected = false;
-    this.waiter = null;
+    this.drainWaiter = null;
+    this.readWaiter = null;
   }
 
   /**
@@ -318,21 +323,19 @@ class NTTCP {
   send(buf) {
     this.checkErr();
     if (process.env.NODE_ORACLEDB_DEBUG_PACKETS)
-      this.printPacket("Sending packet", buf);
+      this.printPacket(`Sending packet ${this.packetNum} on stream ${this.streamNum}`, buf);
     const result = this.stream.write(buf, (err) => {
       if (err) {
         this.savedErr = err;
         this.err = true;
-        if (this.waiter) {
-          this.waiter();
-          this.waiter = null;
-        }
+        this._notifyWaiters();
       }
     });
     if (!result) {
       this.needsDrain = true;
     }
     this.numPacketsSinceLastWait++;
+    this.packetNum++;
   }
 
   /**
@@ -353,11 +356,7 @@ class NTTCP {
     this.checkErr();
     if (this.needsDrain) {
       await new Promise((resolve) => {
-        this.waiter = resolve;
-        this.stream.once('drain', () => {
-          resolve();
-          this.waiter = null;
-        });
+        this.drainWaiter = resolve;
       });
       this.checkErr();
     } else {
@@ -400,15 +399,16 @@ class NTTCP {
         const packet = {
           buf: tempBuf.subarray(0, len),
           type: tempBuf[4],
-          flags: tempBuf[5]
+          flags: tempBuf[5],
+          num : this.packetNum++
         };
         this.packets.push(packet);
-        if (this.waiter) {
-          this.waiter();
-          this.waiter = null;
+        if (this.readWaiter) {
+          this.readWaiter();
+          this.readWaiter = null;
         }
         if (process.env.NODE_ORACLEDB_DEBUG_PACKETS)
-          this.printPacket("Receiving packet", packet.buf);
+          this.printPacket(`Receiving packet ${packet.num} on stream ${this.streamNum}`, packet.buf);
 
         // if the packet consumed all of the bytes (most common scenario), then
         // simply clear the temporary buffer; otherwise, retain whatever bytes
@@ -442,7 +442,7 @@ class NTTCP {
     if (this.packets.length === 0) {
       this.checkErr();
       await new Promise((resolve) => {
-        this.waiter = resolve;
+        this.readWaiter = resolve;
         this.numPacketsSinceLastWait = 0;
       });
       this.checkErr();
@@ -478,26 +478,25 @@ class NTTCP {
     this.stream.on('error', (err) => {
       this.savedErr = err;
       this.err = true;
-      if (this.waiter) {
-        this.waiter();
-        this.waiter = null;
-      }
+      this._notifyWaiters();
     });
 
     this.stream.on('end', () => {
       this.err = true;
-      if (this.waiter) {
-        this.waiter();
-        this.waiter = null;
-      }
+      this._notifyWaiters();
     });
 
     this.stream.on('close', () => {
       this.connected = false;
+      this._notifyWaiters();
     });
 
     this.stream.on('drain', () => {
       this.needsDrain = false;
+      if (this.drainWaiter) {
+        this.drainWaiter();
+        this.drainWaiter = null;
+      }
     });
 
   }
@@ -519,6 +518,20 @@ class NTTCP {
       }
       default:
         errors.throwErr(errors.ERR_INTERNAL, "getOption not supported for opcode " + opcode);
+    }
+  }
+
+  /**
+   * Notify the waiters (drain and read) and reset them, if applicable.
+   */
+  _notifyWaiters() {
+    if (this.drainWaiter) {
+      this.drainWaiter();
+      this.drainWaiter = null;
+    }
+    if (this.readWaiter) {
+      this.readWaiter();
+      this.readWaiter = null;
     }
   }
 

--- a/lib/thin/sqlnet/packet.js
+++ b/lib/thin/sqlnet/packet.js
@@ -52,7 +52,7 @@ function ConnectPacket(connectData, sAtts, flags = 0) {
   }
 
   /* Building Connect Packet */
-  this.buf = Buffer.alloc(size);
+  this.buf = Buffer.allocUnsafe(size).fill(0);
   this.buf.writeUInt16BE(size, constants.NSPHDLEN);
   this.buf.writeUInt8(flags, constants.NSPHDFLGS);
   this.buf.writeUInt8(constants.NSPTCN, constants.NSPHDTYP);
@@ -142,24 +142,24 @@ function ConnectPacket(connectData, sAtts, flags = 0) {
  * @param {int} size of Data Packet
  * @param {boolean} isLargeSDU Large SDU
  */
-function DataPacket(size, isLargeSDU) {
+function DataPacket(isLargeSDU) {
   this.dataPtr = 0; /* data offset start */
   this.dataLen = 0; /* data offset end */
-  this.bufLen = size; /* Length of buffer */
   this.offset = 0; /* Offset for buffer read/write (fastpath) */
   this.len = 0; /* Length of buffer read/write (fastpath) */
+  this.bufLen = 0; /* Length of buffer */
 
   /**
    * Create the Data Packet(Internal)
    */
-  this.createPacket = function() {
+  this.createPacket = function(len) {
     /* Building Data Packet */
     this.dataPtr = constants.NSPDADAT;
     this.dataLen = constants.NSPDADAT;
-
-    this.buf = Buffer.alloc(size);
+    this.buf = Buffer.allocUnsafe(len).fill(0);
     this.buf.writeUInt8(0, constants.NSPHDFLGS);
     this.buf.writeUInt8(constants.NSPTDA, constants.NSPHDTYP);
+    this.bufLen = len; /* Length of buffer */
   };
 
   /**
@@ -173,7 +173,7 @@ function DataPacket(size, isLargeSDU) {
     let bytes2Copy;
 
     if (!this.buf) {
-      this.createPacket();
+      this.createPacket(len + constants.NSPDADAT); //Currently NS data packets are being used only in the connect/disconnect phase
     }
 
     if (len > this.bufLen - this.dataLen) {
@@ -377,7 +377,7 @@ function ControlPacket() {
         } else if (err1 == NSESENDMESG) {
           this.errno = err1;
           this.notifLen = err2;
-          this.notif = Buffer.alloc(err2 + 1);
+          this.notif = Buffer.allocUnsafe(err2 + 1).fill(0);
           this.buf.copy(this.notif, 0, constants.NSPCTLDAT + 12, constants.NSPCTLDAT + 12 + err2);
         } else {
           this.errno = err1;

--- a/lib/thin/sqlnet/paramParser.js
+++ b/lib/thin/sqlnet/paramParser.js
@@ -163,22 +163,19 @@ class NLParamParser {
     let res = ibuf.split(/\r?\n/).filter(element => element);
     for (let i = 0; i < res.length; i++) {
       if (res[i].charAt(0) != '(') {
-        res[i] = '(' + res[i];
-      }
-      if (res[i].charAt(res[i].length - 1 != ')')) {
-        res[i] = res[i] + ')';
+        res[i] = '(' + res[i] + ')';
       }
       let nvp = createNVPair(res[i]);
       let name = nvp.name;
       let uname = name.toUpperCase();
       nvp.name = uname;
-      this.add_NLPListElement(uname, nvp);
+      const unames = uname.split(","); //multiple aliases (alias1, alias2, alias3)
+      for (let i = 0; i < unames.length; i++) {
+        this.ht.set(unames[i], nvp);
+      }
     }
   }
 
-  add_NLPListElement(name, value) {
-    this.ht.set(name, value);
-  }
 
   toString() {
     let out = "";

--- a/lib/thin/statement.js
+++ b/lib/thin/statement.js
@@ -93,6 +93,7 @@ class Statement {
     this.queryVars = [];
     this.bindInfoDict = new Map();
     this.requiresFullExecute = false;
+    this.noPrefetch = false;
     this.returnToCache = false;
     this.numColumns = 0;
     this.lastRowIndex;

--- a/lib/thin/util.js
+++ b/lib/thin/util.js
@@ -28,6 +28,26 @@
 
 const constants = require('../constants');
 const errors = require('../errors.js');
+const os = require('os');
+
+//---------------------------------------------------------------------------
+// populateClientInfo()
+//
+// Populates client process information
+//---------------------------------------------------------------------------
+function populateClientInfo() {
+  this.program = process.argv0;
+  this.terminal = "unknown";
+  this.pid = process.pid.toString();
+  try {
+    this.userName = os.userInfo().username;
+  } catch {
+    this.userName = "unknown";
+  }
+  this.hostName = os.hostname();
+}
+// Initialize client data on startup.
+const CLIENT_INFO = new populateClientInfo();
 
 //---------------------------------------------------------------------------
 // getMetadataMany(sql)
@@ -280,6 +300,7 @@ function checkCredentials(params) {
 module.exports = {
   getMetadataMany,
   cleanSql,
+  CLIENT_INFO,
   getExecuteOutBinds,
   getExecuteManyOutBinds,
   getOutBinds,

--- a/lib/version.js
+++ b/lib/version.js
@@ -31,6 +31,6 @@
 module.exports = {
   VERSION_MAJOR: 6,
   VERSION_MINOR: 0,
-  VERSION_PATCH: 1,
+  VERSION_PATCH: 3,
   VERSION_SUFFIX: ''
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oracledb-prebuilt-for-lambda",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "description": "Node OracleDB Client, pre-built for AWS Lambda",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Based from node-oracledb v6.0.3
- https://node-oracledb.readthedocs.io/en/latest/release_notes.html#node-oracledb-v6-0-1-07-jun-2023

## v6.0.3 Release Notes

### Common Changes
1.  Fixed bug to consistently use the DRCP [`oracledb.connectionClass`](https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#oracledb.connectionClass "oracledb.connectionClass") in effect when the pool was created.    
2.  Added more test cases for datetime objects and other test improvements.
3.  Documentation improvements.

### Thin Mode Changes
1.  Fixed bug that throws the NJS-111 internal error, on the second SELECT SQL statement issued after the first SELECT SQL statement call on an empty table with LOBs.
2.  Avoid throwing errors when calls to `os.userInfo()` fail. [Issue #1564](https://github.com/oracle/node-oracledb/issues/1564).
3.  Persist in-band notifications after calls to `connection.isHealthy()`.
4.  Improved memory usage by removing an unused network buffer.
5.  Fixed bug to handle breaks that occur in the middle of processing a database response that spans multiple packets. This break could occur due to a server error, the session being killed or a call to `breakExecution()`.
6.  Fixed bug where NJS-112 is thrown intermittently with some connections.
7.  Fixed bug where DRCP connections from the application-side connection pool cause the NUM_MISSES values to increase instead of the NUM_HITS values in the V$CPOOL_STATS view by default. This fix optimizes the use of DRCP connections.
8.  Fixed the issue where dates with negative years are not inserted and fetched correctly.
9.  Error handling and message improvements:
    -   Fixed error handling when invalid connect descriptor syntax is used.
    -   Throws an error when https_proxy is given but the protocol is tcp.
    -   Fixed bug to handle errors that occur while waiting for writes to drain on the network.
    -   Improved the error message thrown when an internal error handler fails and a connection is no longer usable
    -   Improved error message when an unsupported protocol is used in Easy Connect syntax.
    -   Add packet number and position for network packets to provide improved diagnosability on some internal errors.